### PR TITLE
Add info to avoid problems when restoring from backup

### DIFF
--- a/lessons/articles/rpb4_debian_12/README.md
+++ b/lessons/articles/rpb4_debian_12/README.md
@@ -113,7 +113,13 @@ newgrp docker
 Загружаем - `wget https://github.com/home-assistant/supervised-installer/releases/download/1.5.0/homeassistant-supervised.deb`    
 Установка - `sudo dpkg -i homeassistant-supervised.deb`    
 
-:arrow_right: Веб интерфейс Home Assistant - `http://IP adress:8123`    
+:arrow_right: Веб интерфейс Home Assistant - `http://IP adress:8123`
+
+:ballot_box_with_check: Если восстанавливаемся из бекапа, надо предварительно перезагрузиться - 
+```yaml
+reboot
+```
+Проверять процесс восстановления из бекапа можно командой `ha supervisor logs`   
 
 :arrow_right: Информация о системе - `http://IP adress:8123/hassio/system`    
 


### PR DESCRIPTION
Ребут перед восстановлением из бекапа помогает избежать проблемы https://community.home-assistant.io/t/homeassistantcore-update-blocked-from-execution-system-is-not-healthy/400773
Это весьма важное дополнение, т.к. HA никак не показывает, что восстановление из бекапа завершилось неудачей. Я так однаждый всю ночь прождал.